### PR TITLE
ArgoCD upgrade and cleanup fixes

### DIFF
--- a/addons/argocd/disable
+++ b/addons/argocd/disable
@@ -15,9 +15,18 @@ echo "Disabling ArgoCD"
 $HELM delete argo-cd -n $NAMESPACE_ARGOCD
 
 $KUBECTL delete customresourcedefinition applications.argoproj.io \
+                applicationsets.argoproj.io \
                 argocdextensions.argoproj.io  \
                 appprojects.argoproj.io
 
-$KUBECTL delete $KUBECTL_DELETE_ARGS namespace "$NAMESPACE_ARGOCD" > /dev/null 2>&1 || true
+if [[ "$1" == "--purge" ]]; then
+    $KUBECTL delete $KUBECTL_DELETE_ARGS namespace "$NAMESPACE_ARGOCD" > /dev/null 2>&1 || true
+else
+    echo ""
+    echo "WARNING: Deletion of \"$NAMESPACE_ARGOCD\" namespace must be enforced by: microk8s disable argocd --purge"
+    echo ""
+    echo "Purge only when sure, that \"$NAMESPACE_ARGOCD\" namespace is not hosting any other services from Argo stack."
+    echo ""
+fi
 
 echo "ArgoCD disabled"

--- a/addons/argocd/enable
+++ b/addons/argocd/enable
@@ -6,7 +6,7 @@ source $SNAP/actions/common/utils.sh
 
 NAMESPACE_ARGOCD="argocd"
 
-ARGOCD_HELM_VERSION="4.5.0"
+ARGOCD_HELM_VERSION="4.6.3"
 
 KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 


### PR DESCRIPTION
1. Upgrading ArgoCD to the latest version
2. Fixing incomplete cleanup (ArgoCD Custom Resources)
3. (optional) Conditional deletion of "argocd" namespace. Preventing accidental removal of other Argo components sharing the same namespace. Oftentimes e.g. ArgoCD Image Updater or Argo Notifications share the same namespace with ArgoCD. Current version of deletion script may destroy complete Argo stack (regardless whether the other components are deployed as addons or manually). Copy-pasting of this logic for further Argo addons can even increase the danger.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
